### PR TITLE
Added tilt commands, fixed some bugs

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -149,6 +149,9 @@
 // M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
 // M666 - set delta endstop adjustemnt
 // M605 - Set dual x-carriage movement mode: S<mode> [ X<duplication x-offset> R<duplication temp offset> ]
+// M650 - [mUVe3D] - Set peel distance
+// M651 - [mUVe3D] - Execute peel move
+// M652 - [mUVe3D] - Turn off laser now
 // M907 - Set digital trimpot motor current using axis codes.
 // M908 - Control digital trimpot directly.
 // M350 - Set microstepping mode.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2530,7 +2530,12 @@ void process_commands()
     {
         // Can only untilt if tilted
         if (tilted) {
-           plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + tilt_distance, destination[Z_AXIS] + tilt_distance, 30, active_extruder);
+           // To prevent subsequent commands from not knowing our
+           // actual position, update the Z axis, then move to it.
+           destination[Z_AXIS] += tilt_distance;
+           plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], 30, active_extruder);
+           // And save it away as our current position, because we're there.
+           memcpy(current_position, destination, sizeof(current_position));
            st_synchronize();
            tilted = false;
         }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2525,7 +2525,7 @@ void process_commands()
     {
         // Double tilts are not allowed.
         if (!tilted) {      
-          plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + tilt_distance, destination[Z_AXIS], 30, active_extruder);
+          plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + tilt_distance, destination[Z_AXIS], retract_speed, active_extruder);
           st_synchronize();
           tilted = true;
         }
@@ -2539,7 +2539,7 @@ void process_commands()
            // To prevent subsequent commands from not knowing our
            // actual position, update the Z axis, then move to it.
            destination[Z_AXIS] += tilt_distance;
-           plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], 30, active_extruder);
+           plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], retract_speed, active_extruder);
            // And save it away as our current position, because we're there.
            memcpy(current_position, destination, sizeof(current_position));
            st_synchronize();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -149,12 +149,11 @@
 // M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
 // M666 - set delta endstop adjustemnt
 // M605 - Set dual x-carriage movement mode: S<mode> [ X<duplication x-offset> R<duplication temp offset> ]
-// M650 - [mUVe3D] - Set peel distance
+// M650 - [mUVe3D] - Set peel and tilt distances
 // M651 - [mUVe3D] - Execute peel move
 // M652 - [mUVe3D] - Turn off laser now
-// M653 - [mUVe3D] - Set tilt distance
-// M654 - [mUVe3D] - Execute tilt move
-// M655 - [mUVe3D] - Execute untilt move
+// M653 - [mUVe3D] - Execute tilt move
+// M654 - [mUVe3D] - Execute untilt move
 // M907 - Set digital trimpot motor current using axis codes.
 // M908 - Control digital trimpot directly.
 // M350 - Set microstepping mode.
@@ -2472,6 +2471,17 @@ void process_commands()
       else {
           laser_power=255;
         }
+      if(code_seen('T')) {
+        tilt_distance = (float) code_value();
+      }
+      else {
+        tilt_distance = 20;
+      }
+      // Initialize tilted to false. The intent here is that you would send this command at the start of a print job, and
+      // the platform would be level when you do. As such, we assume that you either hand-cranked it to level, or executed 
+      // an M655 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
+      // your print job is going to go poorly.
+      tilted = false;
     }
     break;
     
@@ -2505,24 +2515,7 @@ void process_commands()
     }
     break;
 
-    case 653: // M653 - set tilt parameters
-    {
-      st_synchronize();
-      if(code_seen('D')) {
-        tilt_distance = (float) code_value();
-      }
-      else {
-        tilt_distance = 20;
-      }
-      // Initialize tilted to false. The intent here is that you would send this command at the start of a print job, and
-      // the platform would be level when you do. As such, we assume that you either hand-cranked it to level, or executed 
-      // an M655 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
-      // your print job is going to go poorly.
-      tilted = false;
-    }
-    break;
-
-    case 654: // M654 - execute tilt move
+    case 653: // M653 - execute tilt move
     {
         // Double tilts are not allowed.
         if (!tilted) {      
@@ -2533,7 +2526,7 @@ void process_commands()
     }
     break;
 
-    case 655: // M655 - execute untilt move
+    case 654: // M654 - execute untilt move
     {
         // Can only untilt if tilted
         if (tilted) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2498,6 +2498,7 @@ void process_commands()
      analogWrite(LASER_PIN, 0); //turn off laser
      st_synchronize();
     }
+    break;
     
     case 907: // M907 Set digital trimpot motor current using axis codes.
     {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -226,10 +226,10 @@ float delta[3] = {0.0, 0.0, 0.0};
 //===========================================================================
 const char axis_codes[NUM_AXIS] = {'X', 'Y', 'Z', 'E'};
 static float destination[NUM_AXIS] = {  0.0, 0.0, 0.0, 0.0};
-static float peel_distance = 0; //User by mUVe 3D Peel Control
+static float peel_distance = 0; //Used by mUVe 3D Peel Control
 static float peel_speed = 0; //Used by mUVe 3D Peel Control
 static float peel_pause = 0; //Used by mUVe 3D Peel Control
-static float laser_power = 0; //Used by mUVe 3D laser control
+static float laser_power = 0; //Used by mUVe 3D laser Control
 static float offset[3] = {0.0, 0.0, 0.0};
 static bool home_all_axis = true;
 static float feedrate = 1500.0, next_feedrate, saved_feedrate;


### PR DESCRIPTION
This has been lightly tested.
1. Manually set GCode until I was convinced it did what I wanted it to do.
2. Ran a print job (no resin) with the config [here](https://github.com/mattcaron/mUVe3D_configs/blob/master/Profiles/mUVe%201%20FullHD%20MJ%20SF%20Green.slicing). Essentially, it does:
   
   ```
   M650 D$ZLiftDist S$ZLiftRate P0 T20;mUVe 1 Prefs
   ```
   
   in the start, and:
   
   ```
   M653 ; Do mUVe tilt move.
   ```
   
   in the end, and then I issued a M654 command to relevel it when the print job was completed.
