### PR TITLE
Added projector control on Serial port 2

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -27,6 +27,13 @@
 //#define BAUDRATE 250000
 #define BAUDRATE 115200
 
+// PROJECTOR_SERIAL_PORT selects which serial port should be used to
+// control a projector.
+#define PROJECTOR_SERIAL_PORT 2
+
+// This determines the communication speed of the projector
+#define PROJECTOR_BAUDRATE 115200
+
 //// The following define selects which electronics board you have. Please choose the one that matches your setup
 // 10 = Gen7 custom (Alfons3 Version) "https://github.com/Alfons3/Generation_7_Electronics"
 // 11 = Gen7 v1.1, v1.2 = 11
@@ -591,6 +598,10 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 
 #include "Configuration_adv.h"
 #include "thermistortables.h"
+
+#if defined(PROJECTOR_SERIAL_PORT) && PROJECTOR_SERIAL_PORT == 2 && defined(NEWPANEL)
+    #error Oops! NEWPANEL style LCD panel is incompatible with using SERIAL_PORT2
+#endif
 
 #endif //__CONFIGURATION_H
 

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -35,6 +35,13 @@
   }
 #endif
 
+#if defined(P_USARTx_RX_vect)
+  ISR(P_USARTx_RX_vect)
+  {
+    PSerial.isr();
+  }
+#endif
+
 // Constructors ////////////////////////////////////////////////////////////////
 
 MarlinSerial::MarlinSerial()
@@ -367,6 +374,9 @@ void MarlinSerial::setRegisters(void)
 // Preinstantiate Objects //////////////////////////////////////////////////////
 
 MarlinSerial MSerial;
+#if defined (PROJECTOR_SERIAL_PORT)
+MarlinSerial PSerial;
+#endif
 
 #endif // whole file
 #endif // !AT90USB

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -46,6 +46,10 @@
 #define M_USARTx_RX_vect SERIAL_REGNAME(USART,SERIAL_PORT,_RX_vect)
 #endif
 
+// Interrupt vector for projector serial port
+#ifdef PROJECTOR_SERIAL_PORT
+#define P_USARTx_RX_vect SERIAL_REGNAME(USART,PROJECTOR_SERIAL_PORT,_RX_vect)
+#endif
 
 #define DEC 10
 #define HEX 16
@@ -110,7 +114,7 @@ class MarlinSerial //: public Stream
       }
     }
 
-#if UART_PRESENT(SERIAL_PORT)
+#if UART_PRESENT(SERIAL_PORT) || UART_PRESENT(PROJECTOR_SERIAL_PORT)
     // Interrupt service routine. Only necessary if there is a real UART.
     FORCE_INLINE void isr()
     {
@@ -185,7 +189,7 @@ class MarlinSerial //: public Stream
     void setRegisters(void);
     byte portNum;
 
-#if UART_PRESENT(SERIAL_PORT)
+#if UART_PRESENT(SERIAL_PORT) || UART_PRESENT(PROJECTOR_SERIAL_PORT)
     ring_buffer rx_buffer;
 #endif
 
@@ -203,6 +207,8 @@ class MarlinSerial //: public Stream
 };
 
 extern MarlinSerial MSerial;
+extern MarlinSerial PSerial;
+
 #endif // !AT90USB
 
 #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -41,21 +41,10 @@
 #define SERIAL_REGNAME_INTERNAL(registerbase,number,suffix) registerbase##number##suffix
 #endif
 
-// Registers used by MarlinSerial class (these are expanded 
-// depending on selected serial port
-#define M_UCSRxA SERIAL_REGNAME(UCSR,SERIAL_PORT,A) // defines M_UCSRxA to be UCSRnA where n is the serial port number
-#define M_UCSRxB SERIAL_REGNAME(UCSR,SERIAL_PORT,B) 
-#define M_RXENx SERIAL_REGNAME(RXEN,SERIAL_PORT,)    
-#define M_TXENx SERIAL_REGNAME(TXEN,SERIAL_PORT,)    
-#define M_RXCIEx SERIAL_REGNAME(RXCIE,SERIAL_PORT,)    
-#define M_UDREx SERIAL_REGNAME(UDRE,SERIAL_PORT,)    
-#define M_UDRx SERIAL_REGNAME(UDR,SERIAL_PORT,)  
-#define M_UBRRxH SERIAL_REGNAME(UBRR,SERIAL_PORT,H)
-#define M_UBRRxL SERIAL_REGNAME(UBRR,SERIAL_PORT,L)
-#define M_RXCx SERIAL_REGNAME(RXC,SERIAL_PORT,)
+// Interrupt vector for main serial port
+#ifdef SERIAL_PORT
 #define M_USARTx_RX_vect SERIAL_REGNAME(USART,SERIAL_PORT,_RX_vect)
-#define M_U2Xx SERIAL_REGNAME(U2X,SERIAL_PORT,)
-
+#endif
 
 
 #define DEC 10
@@ -80,16 +69,12 @@ struct ring_buffer
   int tail;
 };
 
-#if UART_PRESENT(SERIAL_PORT)
-  extern ring_buffer rx_buffer;
-#endif
-
 class MarlinSerial //: public Stream
 {
 
   public:
     MarlinSerial();
-    void begin(long);
+    void begin(byte, long);
     void end();
     int peek(void);
     int read(void);
@@ -102,17 +87,16 @@ class MarlinSerial //: public Stream
     
     FORCE_INLINE void write(uint8_t c)
     {
-      while (!((M_UCSRxA) & (1 << M_UDREx)))
+      while (!((*UCSRxA) & (1 << (UDREx))))
         ;
 
-      M_UDRx = c;
+      *UDRx = c;
     }
-    
     
     FORCE_INLINE void checkRx(void)
     {
-      if((M_UCSRxA & (1<<M_RXCx)) != 0) {
-        unsigned char c  =  M_UDRx;
+      if((*UCSRxA & (1 << RXCx)) != 0) {
+        unsigned char c = *UDRx;
         int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;
 
         // if we should be storing the received character into the location
@@ -125,15 +109,33 @@ class MarlinSerial //: public Stream
         }
       }
     }
-    
-    
-    private:
-    void printNumber(unsigned long, uint8_t);
-    void printFloat(double, uint8_t);
-    
-    
-  public:
-    
+
+#if UART_PRESENT(SERIAL_PORT)
+    // Interrupt service routine. Only necessary if there is a real UART.
+    FORCE_INLINE void isr()
+    {
+      unsigned char c  =  *UDRx;
+      store_char(c);
+    }
+
+    // Helper for above, also only necessary if there is a real UART.
+    FORCE_INLINE void store_char(unsigned char c)
+    {
+        int i;
+        
+        i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;
+        
+        // if we should be storing the received character into the location
+        // just before the tail (meaning that the head would advance to the
+        // current location of the tail), we're about to overflow the buffer
+        // and so we don't write the character or advance the head.
+        if (i != rx_buffer.tail) {
+          rx_buffer.buffer[rx_buffer.head] = c;
+          rx_buffer.head = i;
+        }
+    }
+#endif
+
     FORCE_INLINE void write(const char *str)
     {
       while (*str)
@@ -176,6 +178,28 @@ class MarlinSerial //: public Stream
     void println(unsigned long, int = DEC);
     void println(double, int = 2);
     void println(void);
+
+    private:
+    void printNumber(unsigned long, uint8_t);
+    void printFloat(double, uint8_t);
+    void setRegisters(void);
+    byte portNum;
+
+#if UART_PRESENT(SERIAL_PORT)
+    ring_buffer rx_buffer;
+#endif
+
+    volatile uint8_t *UCSRxA;
+    volatile uint8_t *UCSRxB;
+    int RXENx;
+    int TXENx;
+    int RXCIEx;
+    int UDREx;
+    volatile uint8_t *UDRx;
+    volatile uint8_t *UBRRxH;
+    volatile uint8_t *UBRRxL;
+    int RXCx;
+    int U2Xx;
 };
 
 extern MarlinSerial MSerial;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -468,6 +468,10 @@ void setup()
   lcd_init();
   _delay_ms(1000);	// wait 1sec to display the splash screen
 
+#if defined(PROJECTOR_SERIAL_PORT) && defined(PROJECTOR_BAUDRATE)
+  PSerial.begin(PROJECTOR_SERIAL_PORT, PROJECTOR_BAUDRATE);
+#endif
+
   #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
     SET_OUTPUT(CONTROLLERFAN_PIN); //Set pin used for driver cooling fan
   #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2710,6 +2710,9 @@ void process_commands()
         for(int8_t i=0; i < NUM_AXIS; i++) {
             current_position[i] = destination[i];
         }
+
+        SERIAL_ECHOLNPGM("Z_move_comp");
+        st_synchronize();
     }
     break;
     

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -419,7 +419,7 @@ void setup()
 {
   setup_killpin();
   setup_powerhold();
-  MYSERIAL.begin(BAUDRATE);
+  MYSERIAL.begin(SERIAL_PORT,BAUDRATE);
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START;
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2555,8 +2555,8 @@ void process_commands()
     }
     break;
 
-    case 655: // M655 - send projector control commands via bitbanged
-              // serial level shifter.
+    case 655: // M655 - send projector control commands via serial
+              // level shifter hooked to predefined UART
     {
         int tempVal = -1;
         

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2523,7 +2523,6 @@ void process_commands()
         lcd_update();      
       }
     
-        plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS] + peel_distance, retract_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], retract_speed, active_extruder);
         st_synchronize();
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2486,7 +2486,7 @@ void process_commands()
       }
       // Initialize tilted to false. The intent here is that you would send this command at the start of a print job, and
       // the platform would be level when you do. As such, we assume that you either hand-cranked it to level, or executed 
-      // an M655 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
+      // an M654 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
       // your print job is going to go poorly.
       tilted = false;
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2487,7 +2487,7 @@ void process_commands()
       }
       // Initialize tilted to false. The intent here is that you would send this command at the start of a print job, and
       // the platform would be level when you do. As such, we assume that you either hand-cranked it to level, or executed 
-      // an M655 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
+      // an M654 command via manual GCode before running a new print job. If not, then the platform is currently tilted, and
       // your print job is going to go poorly.
       tilted = false;
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2508,6 +2508,7 @@ void process_commands()
         lcd_update();      
       }
     
+        plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS] + peel_distance, retract_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], retract_speed, active_extruder);
         st_synchronize();
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2511,17 +2511,16 @@ void process_commands()
     {
         st_synchronize();
 
-        if(peel_distance > 0);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + peel_distance, destination[Z_AXIS], peel_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
+
         st_synchronize();
-        if(peel_pause > 0);
-        st_synchronize();
+
         codenum = peel_pause;
         codenum += millis();  // keep track of when we started waiting
         previous_millis_cmd = millis();
 
-        while(millis()  < codenum ){
+        while (millis()  < codenum ) {
             manage_heater();
             manage_inactivity();
             lcd_update();
@@ -2536,14 +2535,16 @@ void process_commands()
         // Move up by one layer thickness
 
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]+ peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
+
         st_synchronize();
 
         // Retract movement is done in two phases. First the Z axis moves down and then the E axis.
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS] + peel_distance, retract_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], retract_speed, active_extruder);
+
         st_synchronize();
 
-        for(int8_t i=0; i < NUM_AXIS; i++) {
+        for (int8_t i=0; i < NUM_AXIS; i++) {
             current_position[i] = destination[i];
         }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -154,6 +154,7 @@
 // M652 - [mUVe3D] - Turn off laser now
 // M653 - [mUVe3D] - Execute tilt move
 // M654 - [mUVe3D] - Execute untilt move
+// M655 - [mUVe3D] - Projector control
 // M907 - Set digital trimpot motor current using axis codes.
 // M908 - Control digital trimpot directly.
 // M350 - Set microstepping mode.
@@ -2553,7 +2554,114 @@ void process_commands()
         }
     }
     break;
-    
+
+    case 655: // M655 - send projector control commands via bitbanged
+              // serial level shifter.
+    {
+        int tempVal = -1;
+        
+        // Viewsonic commands
+        if(code_seen('V')) {
+            tempVal = (float) code_value();
+
+            switch(tempVal)
+            {
+            case 0: // Power Off
+                {
+                    // 0614000400341101005E
+                    const byte off[] = {0x06, 0x14, 0x00, 0x04, 0x00, 
+                                        0x34, 0x11, 0x01, 0x00, 0x5E};
+                    PSerial.write(off, sizeof(off));
+                }
+                break;
+            case 1: // Power On
+                {
+                    // 0614000400341100005D
+                    const byte on[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                       0x34, 0x11, 0x00, 0x00, 0x5D};
+                    PSerial.write(on, sizeof(on));
+                }
+                break;
+            case 2: // Factory Reset
+                {
+                    // 0614000400341102005F
+                    const byte reset[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                          0x34, 0x11, 0x02, 0x00, 0x5F};
+                    PSerial.write(reset, sizeof(reset));
+                }
+                break;
+            case 3: // Splash Screen Black
+                {
+                    // 061400040034110A0067
+                    const byte blackScreen[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                                0x34, 0x11, 0x0A, 0x00, 0x67};
+                    PSerial.write(blackScreen, sizeof(blackScreen));
+                }
+                break;
+            case 4: // High Altitude On
+                {
+                    // 061400040034110C016A
+                    const byte HAOn[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                         0x34, 0x11, 0x0C, 0x01, 0x6A};
+                    PSerial.write(HAOn, sizeof(HAOn));
+                }
+                break;
+            case 5: // High Altitude Off
+                {
+                    // 061400040034110C0069
+                    const byte HAOff[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                          0x34, 0x11, 0x0C, 0x00, 0x69};
+                    PSerial.write(HAOff, sizeof(HAOff));
+                }
+                break;
+            case 6: // Lamp Mode Normal
+                {
+                    // 0614000400341110006D
+                    const byte lampNormal[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                               0x34, 0x11, 0x10, 0x00, 0x6D};
+                    PSerial.write(lampNormal, sizeof(lampNormal));
+                }
+                break;
+            case 7: // Contrast Decrease
+                {
+                    // 06140004003412020060
+                    const byte contDec[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                            0x34, 0x12, 0x02, 0x00, 0x60};
+                    PSerial.write(contDec, sizeof(contDec));
+                }
+                break;
+            case 8: // Contrast Increase
+                {
+                    // 06140004003412020161
+                    const byte contInc[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                            0x34, 0x12, 0x02, 0x01, 0x61};
+                    PSerial.write(contInc, sizeof(contInc));
+                }
+                break;
+            case 9: // Brightness Decrease
+                {
+                    // 06140004003412030061
+                    const byte brightDec[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                              0x34, 0x12, 0x03, 0x00, 0x61};
+                    PSerial.write(brightDec, sizeof(brightDec));
+                }
+                break;
+            case 10: // Brightness Increase
+                {
+                    // 06140004003412030162
+                    const byte brightInc[] = {0x06, 0x14, 0x00, 0x04, 0x00,
+                                              0x34, 0x12, 0x03, 0x01, 0x62};
+                    PSerial.write(brightInc, sizeof(brightInc));
+                }
+                break;
+
+            // Other commands go here.
+            }
+        }
+        // Other projector models go here
+    }
+    break;
+
     case 907: // M907 Set digital trimpot motor current using axis codes.
     {
       #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -237,7 +237,7 @@ static float peel_pause = 0; //Used by mUVe 3D Peel Control
 static float laser_power = 0; //Used by mUVe 3D laser Control
 static float retract_speed = 0; //Used by mUVe 3D Peel Control
 static float tilt_distance = 0; //Used by mUVe 3D Tilt Control
-static float layer_thickness = 0; //Used by mUVe 3D M655 modified Peel
+static float layer_thickness = 0; //Used by mUVe 3D M699 modified Peel
 static bool tilted = false; // Whether we're currently tilted. Sending the command again will tell us to un-tilt.
 static float offset[3] = {0.0, 0.0, 0.0};
 static bool home_all_axis = true;
@@ -2557,7 +2557,7 @@ void process_commands()
     }
     break;
 
-    case 655: // M655: Modified version of the M651. Functions: peel
+    case 699: // M699: Modified version of the M651. Functions: peel
               // move and add layer. No need for G1.
     {
         st_synchronize();


### PR DESCRIPTION
This patch extends MarlinSerial to be able different objects to be created for the different serial ports. Right now, up to 4 are supported. I have only tested ports 0 (the default port) and 2. There is also an addition to create a second port if PROJECTOR_SERIAL_PORT is defined on Configuration.h and use that for a projector. It may not compile of PROJECTOR_SERIAL_PORT is not defined as I have not bothered to test that and fix any issues.
