### PR TITLE
Tilted lowering

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2527,16 +2527,17 @@ void process_commands()
         }
 
         // Set new z axes destination
+        if (layer_thickness > 0) {
+            destination[Z_AXIS] = layer_thickness + (axis_relative_modes[Z_AXIS] || relative_mode)*current_position[Z_AXIS];
+            if (destination[Z_AXIS] < min_pos[Z_AXIS]) destination[Z_AXIS] = min_pos[Z_AXIS];
+            if (destination[Z_AXIS] > max_pos[Z_AXIS]) destination[Z_AXIS] = max_pos[Z_AXIS];
 
-        destination[Z_AXIS] = layer_thickness + (axis_relative_modes[Z_AXIS] || relative_mode)*current_position[Z_AXIS];
-        if (destination[Z_AXIS] < min_pos[Z_AXIS]) destination[Z_AXIS] = min_pos[Z_AXIS];
-        if (destination[Z_AXIS] > max_pos[Z_AXIS]) destination[Z_AXIS] = max_pos[Z_AXIS];
+            // Move up by one layer thickness
 
-        // Move up by one layer thickness
-
-        plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]+ peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
-
-        st_synchronize();
+            plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]+ peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
+            
+            st_synchronize();
+        }
 
         // Retract movement is done in two phases. First the Z axis moves down and then the E axis.
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS] + peel_distance, retract_speed, active_extruder);
@@ -2544,14 +2545,15 @@ void process_commands()
 
         st_synchronize();
 
-        for (int8_t i=0; i < NUM_AXIS; i++) {
-            current_position[i] = destination[i];
-        }
-	
-	if(layer_thickness > 0) {
-        	SERIAL_ECHOLNPGM("Z_move_comp");
-	}	
-        st_synchronize();
+        if(layer_thickness > 0) {
+            for (int8_t i=0; i < NUM_AXIS; i++) {
+                current_position[i] = destination[i];
+            }
+            
+            SERIAL_ECHOLNPGM("Z_move_comp");
+
+            st_synchronize();
+	}
     }
     break;
     

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2506,24 +2506,51 @@ void process_commands()
     }
     break;
     
-    case 651: // M651 run peel move and return back to start.
+    case 651: // M651 run peel move and return back down 1 layer
+              // higher. No need for G1 as long as you set H > 0 in M650.
     {
-      if(peel_distance > 0);
+        st_synchronize();
+
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + peel_distance, destination[Z_AXIS], peel_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS] + peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
+
         st_synchronize();
-      if(peel_pause > 0);
-        st_synchronize();
+
         codenum = peel_pause;
         codenum += millis();  // keep track of when we started waiting
         previous_millis_cmd = millis();
-        while(millis()  < codenum ){
-        manage_heater();
-        manage_inactivity();
-        lcd_update();      
-      }
-    
+
+        while (millis()  < codenum ) {
+            manage_heater();
+            manage_inactivity();
+            lcd_update();
+        }
+
+        // Set new z axes destination
+
+        destination[Z_AXIS] = layer_thickness + (axis_relative_modes[Z_AXIS] || relative_mode)*current_position[Z_AXIS];
+        if (destination[Z_AXIS] < min_pos[Z_AXIS]) destination[Z_AXIS] = min_pos[Z_AXIS];
+        if (destination[Z_AXIS] > max_pos[Z_AXIS]) destination[Z_AXIS] = max_pos[Z_AXIS];
+
+        // Move up by one layer thickness
+
+        plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]+ peel_distance, destination[Z_AXIS] + peel_distance, peel_speed, active_extruder);
+
+        st_synchronize();
+
+        // Retract movement is done in two phases. First the Z axis moves down and then the E axis.
+        plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS] + peel_distance, retract_speed, active_extruder);
         plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[Z_AXIS], retract_speed, active_extruder);
+
+        st_synchronize();
+
+        for (int8_t i=0; i < NUM_AXIS; i++) {
+            current_position[i] = destination[i];
+        }
+	
+	if(layer_thickness > 0) {
+        	SERIAL_ECHOLNPGM("Z_move_comp");
+	}	
         st_synchronize();
     }
     break;

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ const bool Z_MIN_ENDSTOP_INVERTING = false;
 Change to:
 const bool Z_MIN_ENDSTOP_INVERTING = true;
 
-M650 D P R S T- 
+M650 D H P R S T- 
 
 	D - Set Distance in mm - Set to 0 to remove the peel
+	
+	H - Layer Height - Set in mm - Default 0 - Remove the current layer height from the peel retract. Useful to combine next layer motion with the peel.
 	
 	R - Set Speed in mm/s - Retract speed of the peel
 


### PR DESCRIPTION
THIS IS UNTESTED but should, theoretically correct the problem with backwards compatibility when H is not set and thus causes the printer to home each time. Now, all the positions are only updated when the layer height is set to a value greater than 0. However, the "tilted lowering" is retained, because that should have nothing to do with the layer height thing.
